### PR TITLE
Make VitaLiteOptionsPanel.java scrollable.

### DIFF
--- a/base-api/src/main/java/com/tonic/model/ui/VitaLiteOptionsPanel.java
+++ b/base-api/src/main/java/com/tonic/model/ui/VitaLiteOptionsPanel.java
@@ -180,7 +180,9 @@ public class VitaLiteOptionsPanel extends VPluginPanel {
         mouseButton.addActionListener(e -> checkMouseValues());
         contentPanel.add(mouseButton);
 
-        add(contentPanel);
+        add(new JScrollPane(contentPanel,
+                ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER));
     }
 
     private JFrame getTransportsEditor()

--- a/base-api/src/main/java/com/tonic/model/ui/componants/VPluginPanel.java
+++ b/base-api/src/main/java/com/tonic/model/ui/componants/VPluginPanel.java
@@ -101,6 +101,6 @@ public abstract class VPluginPanel extends JPanel
     public Dimension getMinimumSize()
     {
         int width = this == wrappedPanel ? PANEL_WIDTH + SCROLLBAR_WIDTH : PANEL_WIDTH;
-        return new Dimension(width, super.getMinimumSize().height);
+        return new Dimension(width, 0);
     }
 }


### PR DESCRIPTION
Stops it from force resizing the client if client window height < VitaLitaOptionsPanel height by setting minimum height to 0 and adding it to a JScrollPane