### PR TITLE
Fix Quest Helper Continue

### DIFF
--- a/api/src/main/java/com/tonic/api/widgets/DialogueAPI.java
+++ b/api/src/main/java/com/tonic/api/widgets/DialogueAPI.java
@@ -11,6 +11,8 @@ import net.runelite.api.Client;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.config.ConfigManager;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,7 +22,9 @@ import java.util.List;
  */
 public class DialogueAPI
 {
-    /**
+    private static final net.runelite.client.config.ConfigManager configManager = Static.getInjector().getInstance(ConfigManager.class);
+
+	/**
      * Retrieves the header of the current dialogue, which may indicate the speaker or context.
      *
      * @return The dialogue header as a String. Possible values include NPC names, "Player", "Select an Option", or "UNKNOWN".
@@ -367,8 +371,12 @@ public class DialogueAPI
         if (dialogOption1kids == null)
             return false;
         int i = 0;
+		String configValue = configManager.getConfiguration("questhelper", "textHighlightColor");
+        if (configValue == null || configValue.isEmpty())
+            return false;
+        int colorCode = Integer.parseInt(configValue);
         for (Widget w : dialogOption1kids) {
-            if (w.getTextColor() != 0 && w.getText().matches("\\[\\d].*")) {
+            if (w.getTextColor() == colorCode) {
                 selectOption(i);
                 return true;
             }


### PR DESCRIPTION
Fixes #30

Old version was specifically looking for color `#00B2B2`.
~~Now checks for color not being black and widget text starting with `[NUMBER]`. Unless you want to check quest helper config every time idk how else you'd get the proper color to check :p~~
Gets the highlight color from ConfigManager now.