### PR TITLE
Fix typo "&" -> "&&"

### DIFF
--- a/plugins/src/main/java/com/tonic/plugins/profiles/panel/ProfilesRootPanel.java
+++ b/plugins/src/main/java/com/tonic/plugins/profiles/panel/ProfilesRootPanel.java
@@ -238,7 +238,7 @@ public class ProfilesRootPanel extends PluginPanel {
 
                 String displayName = nameField.getText();
 
-                if (jagCharacter.getDisplayName() != null & !jagCharacter.getDisplayName().isEmpty()) {
+                if (jagCharacter.getDisplayName() != null && !jagCharacter.getDisplayName().isEmpty()) {
                     displayName = jagCharacter.getDisplayName();
                 }
 


### PR DESCRIPTION
New accounts, i.e. ones with 'null' names, were not successfully null-checked because of previous typo.