### PR TITLE
Fix Imports for New Accounts

### DIFF
--- a/plugins/src/main/java/com/tonic/plugins/profiles/panel/ProfilesRootPanel.java
+++ b/plugins/src/main/java/com/tonic/plugins/profiles/panel/ProfilesRootPanel.java
@@ -238,7 +238,7 @@ public class ProfilesRootPanel extends PluginPanel {
 
                 String displayName = nameField.getText();
 
-                if (jagCharacter.getDisplayName() != null & !jagCharacter.getDisplayName().isEmpty()) {
+                if (jagCharacter.getDisplayName() != null && !jagCharacter.getDisplayName().isEmpty()) {
                     displayName = jagCharacter.getDisplayName();
                 }
 


### PR DESCRIPTION
New accounts (with usernames of NULL) failed to import into profiles, because null-checking failed. Repaired null checking as follows -> fix typo "&" to "&&"