### PR TITLE
post LoginMessage to event bus

### DIFF
--- a/base-api/src/main/java/com/tonic/data/LoginMessage.java
+++ b/base-api/src/main/java/com/tonic/data/LoginMessage.java
@@ -1,0 +1,17 @@
+package com.tonic.data;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LoginMessage {
+    private final String line1;
+    private final String line2;
+    private final String line3;
+
+    @Override
+    public String toString() {
+        return (line1.trim() + " " + line2.trim() + " " + line3.trim()).trim();
+    }
+}

--- a/src/main/java/com/tonic/mixins/TGameEngineMixin.java
+++ b/src/main/java/com/tonic/mixins/TGameEngineMixin.java
@@ -2,6 +2,7 @@ package com.tonic.mixins;
 
 import com.tonic.Static;
 import com.tonic.api.TGameEngine;
+import com.tonic.data.LoginMessage;
 import com.tonic.data.LoginResponse;
 import com.tonic.injector.annotations.*;
 import org.slf4j.Logger;
@@ -49,5 +50,11 @@ public class TGameEngineMixin implements TGameEngine
     public static void onGetLoginError(int code)
     {
         Static.post(LoginResponse.fromIndex(code));
+    }
+
+    @MethodHook("setLoginResponse")
+    public static void onSetLoginResponse(String line1, String line2, String line3)
+    {
+        Static.post(new LoginMessage(line1, line2, line3));
     }
 }


### PR DESCRIPTION
not all responses are handled via getLoginError so this also posts the login message lines to the event bus so we can handle them in plugins

some examples of unhandled responses are the skill total response:
<img width="305" height="161" alt="image" src="https://github.com/user-attachments/assets/ec736eb6-3f90-4a40-8b08-08f8ecd7ef40" />
and whatever this specific world full response is:
<img width="608" height="339" alt="Screenshot 2025-10-16 002055" src="https://github.com/user-attachments/assets/deb5e375-135b-46c8-9062-6ebd968faaaf" />
