### PR TITLE
Fix wrong index in WidgetAPI

### DIFF
--- a/api/src/main/java/com/tonic/api/widgets/WidgetAPI.java
+++ b/api/src/main/java/com/tonic/api/widgets/WidgetAPI.java
@@ -98,7 +98,7 @@ public class WidgetAPI
 
         ItemComposition composition = client.getItemDefinition(widget.getItemId());
 
-        String[] actions = composition.getInventoryActions();
+        String[] actions = widget.getActions(); //composition.getInventoryActions();
         String[][] subOps = composition.getSubops();
 
         if (subOps == null)


### PR DESCRIPTION
composition.getInventoryActions() results in the wrong action index for the packet. use widget.getActions() instead.

reproduce: Widget widget = InventoryAPI.getItem(ring).getWidget();
WidgetAPI.interact(widget,"Rub", "Grand Exchange");


> 
> //composition.getInventoryActions: results in using the "features" menu instead
> INFO  com.tonic.api.widgets.WidgetAPI - widget actions:
> INFO  com.tonic.api.widgets.WidgetAPI - 0:null
> INFO  com.tonic.api.widgets.WidgetAPI - 1:Wear
> INFO  com.tonic.api.widgets.WidgetAPI - 2:Features
> INFO  com.tonic.api.widgets.WidgetAPI - 3:Rub
> INFO  com.tonic.api.widgets.WidgetAPI - 4:Drop
> 
> INFO  com.tonic.api.widgets.WidgetAPI - Interacting with: menu 3, action1
> 
> 
> //widget.getActions()
> WidgetPackets - widget actions:
> WidgetPackets - 0:null
> WidgetPackets - 1:null
> WidgetPackets - 2:Wear
> WidgetPackets - 3:Features
> WidgetPackets - 4:null
> WidgetPackets - 5:Rub
> WidgetPackets - 6:Drop
> WidgetPackets - 7:null
> WidgetPackets - 8:null
> WidgetPackets - 9:Examine
> 
> WidgetPackets -> Interacting with: menu 5, action1
> 
> 
> //getActions:
> WidgetPackets - widget Subops:
> WidgetPackets - 1:null
> WidgetPackets - 2:null
> WidgetPackets - 3:[Boss Log, Coin Collection, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]
> WidgetPackets - 4:[Miscellania, Grand Exchange, Falador, Dondakan, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]
> WidgetPackets - 5:null