### PR TITLE
Add varp requirement to the holy barrier in Paterdomus

### DIFF
--- a/api/src/main/resources/com/tonic/services/pathfinder/transports.json
+++ b/api/src/main/resources/com/tonic/services/pathfinder/transports.json
@@ -53154,7 +53154,17 @@
       "plane": 0
     },
     "action": "Pass-through",
-    "objectId": 3443
+    "objectId": 3443,
+    "requirements": {
+      "varRequirements": [
+        {
+          "comparison": "GREATER_THAN_EQUAL",
+          "type": "VARP",
+          "var": 302,
+          "value": 61
+        }
+      ]
+    }
   },
   {
     "source": {
@@ -76942,18 +76952,18 @@
     "objectId": 2584
   },
   {
-  "source": {
-  "x": 2824,
-  "y": 3117,
-  "plane": 0
-},
-  "destination": {
-  "x": 2830,
-  "y": 9520,
-  "plane": 0
-},
-  "action": "Search",
-  "objectId": 2584
+    "source": {
+      "x": 2824,
+      "y": 3117,
+      "plane": 0
+    },
+    "destination": {
+      "x": 2830,
+      "y": 9520,
+      "plane": 0
+    },
+    "action": "Search",
+    "objectId": 2584
   },
   {
     "source": {


### PR DESCRIPTION
This is the priest in peril varp. Reason you can't just check for quest completion is because there's some extra dialogue after the quest already evaluates as completed. 

This req probably applies to some other transports but idk which they are, just added this one as it's the main way to get into morytania very early game