### PR TITLE
Fix SceneAPI.getSurrounding Bug

### DIFF
--- a/api/src/main/java/com/tonic/api/game/SceneAPI.java
+++ b/api/src/main/java/com/tonic/api/game/SceneAPI.java
@@ -177,7 +177,7 @@ public class SceneAPI {
         {
             for (int y = -radius; y <= radius; y++)
             {
-                out.add(getAt(worldPoint.dx(x).dx(y)));
+                out.add(getAt(worldPoint.dx(x).dy(y)));
             }
         }
 


### PR DESCRIPTION
Original impl had double dx. This correctly replaces with dx and dy.