### PR TITLE
feat(vitalite): Add -disableAutoLogin CLI argument for custom login handling

### DIFF
--- a/api/src/main/java/com/tonic/services/GameManager.java
+++ b/api/src/main/java/com/tonic/services/GameManager.java
@@ -445,13 +445,14 @@ public class GameManager extends Overlay {
                 {
                     String[] parts = AutoLogin.getCredentials().split(":");
                     AutoLogin.setCredentials(null);
+                    boolean shouldActuallyLogin = !Static.getCliArgs().isDisableAutoLogin();
                     if(parts.length == 2)
                     {
-                        LoginService.login(parts[0], parts[1], true);
+                        LoginService.login(parts[0], parts[1], shouldActuallyLogin);
                     }
                     else if(parts.length == 3)
                     {
-                        LoginService.login(parts[0], parts[1], parts[2], true);
+                        LoginService.login(parts[0], parts[1], parts[2], shouldActuallyLogin);
                     }
                 }
                 catch (Exception e)

--- a/base-api/src/main/java/com/tonic/VitaLiteOptions.java
+++ b/base-api/src/main/java/com/tonic/VitaLiteOptions.java
@@ -75,6 +75,12 @@ public class VitaLiteOptions extends OptionsParser
     private String jagexLogin = null;
 
     @CLIArgument(
+            name = "disableAutoLogin",
+            description = "Disables the built-in auto-login feature"
+    )
+    private boolean disableAutoLogin = false;
+
+    @CLIArgument(
             name = "runInjector",
             description = "For use with developing mixins to runt he injector on launch"
     )


### PR DESCRIPTION
Add -disableAutoLogin for Custom Login Handling

Changes
- New CLI argument: -disableAutoLogin disables automatic login to the game while preserving credential passing and preserving Vitalite's current way of logging into anaccount.
- Plugin loop refactor: Loop() now triggers without GameTick/ClientTick when flag is set
- Use case: Enables custom login handling implementations while maintaining plugin control

Usage
Add client argument:
-disableAutoLogin 

Plugin loop() will execute immediately when plugin is enabled, allowing scripts to implement custom login logic.