### PR TITLE
Add accountType to allow shops restricted by account type

### DIFF
--- a/api/src/main/java/com/tonic/data/AccountType.java
+++ b/api/src/main/java/com/tonic/data/AccountType.java
@@ -1,0 +1,53 @@
+package com.tonic.data;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Enumeration representing the different account types in the game.
+ */
+public enum AccountType {
+    NORMAL(0),
+    IRONMAN(1),
+    ULTIMATE_IRONMAN(2),
+    HARDCORE_IRONMAN(3),
+    GROUP_IRONMAN(4),
+    HARDCORE_GROUP_IRONMAN(5),
+    UNRANKED_GROUP_IRONMAN(6);
+
+    /**
+     * A map for looking up AccountType by varbit value.
+     */
+    private static final Map<Integer, AccountType> LOOKUP = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(
+                    AccountType::getVarbitValue,
+                    Function.identity()
+            ));
+
+    private final int varbitValue;
+
+    AccountType(int varbitValue) {
+        this.varbitValue = varbitValue;
+    }
+
+    /**
+     * Gets the varbit value associated with this account type.
+     *
+     * @return the varbit value
+     */
+    public int getVarbitValue() {
+        return varbitValue;
+    }
+
+    /**
+     * Looks up an AccountType by its varbit value.
+     *
+     * @param varbitValue the varbit value to lookup
+     * @return the matching AccountType, or null if not found
+     */
+    public static AccountType fromVarbitValue(int varbitValue) {
+        return LOOKUP.get(varbitValue);
+    }
+}

--- a/api/src/main/java/com/tonic/data/trading/Shop.java
+++ b/api/src/main/java/com/tonic/data/trading/Shop.java
@@ -3,6 +3,7 @@ package com.tonic.data.trading;
 import com.tonic.Logger;
 import com.tonic.Static;
 import com.tonic.api.widgets.ShopAPI;
+import com.tonic.data.AccountType;
 import com.tonic.data.locatables.NpcLocations;
 import com.tonic.services.pathfinder.requirements.*;
 
@@ -1471,6 +1472,27 @@ public enum Shop {
             NpcLocations.TOCI,
             new WorldRequirement(true),
             new QuestRequirement(Quest.CHILDREN_OF_THE_SUN)
+    ),
+    TOCI_GEM_STORE_IRONMAN(
+            InventoryID.ALDARIN_GEM_STORE_IM,
+            NpcLocations.TOCI,
+            new WorldRequirement(true),
+            new QuestRequirement(Quest.CHILDREN_OF_THE_SUN),
+            accountTypeReq(AccountType.IRONMAN)
+    ),
+    TOCI_GEM_STORE_ULTRA_IRONMAN(
+            InventoryID.ALDARIN_GEM_STORE_UIM,
+            NpcLocations.TOCI,
+            new WorldRequirement(true),
+            new QuestRequirement(Quest.CHILDREN_OF_THE_SUN),
+            accountTypeReq(AccountType.ULTIMATE_IRONMAN)
+    ),
+    TOCI_GEM_STORE_GROUP_IRONMAN(
+            InventoryID.ALDARIN_GEM_STORE_GIM,
+            NpcLocations.TOCI,
+            new WorldRequirement(true),
+            new QuestRequirement(Quest.CHILDREN_OF_THE_SUN),
+            accountTypeReq(AccountType.GROUP_IRONMAN)
     ),
     ERCOS_FARMING_SUPPLIES(
             InventoryID.FARMER_SUPPLIES,

--- a/api/src/main/java/com/tonic/data/trading/ShopRequirements.java
+++ b/api/src/main/java/com/tonic/data/trading/ShopRequirements.java
@@ -1,6 +1,7 @@
 package com.tonic.data.trading;
 
 import com.tonic.api.game.SkillAPI;
+import com.tonic.data.AccountType;
 import com.tonic.services.pathfinder.requirements.*;
 import net.runelite.api.Skill;
 import net.runelite.api.gameval.ItemID;
@@ -66,6 +67,21 @@ public final class ShopRequirements {
                 VarType.VARP,
                 VarPlayerID.QP,
                 amount
+        );
+    }
+
+    /**
+     * Creates an account type requirement.
+     *
+     * @param type the required account type
+     * @return a VarRequirement for the specified account type
+     */
+    public static VarRequirement accountTypeReq(AccountType type) {
+        return new VarRequirement(
+                Comparison.EQUAL,
+                VarType.VARBIT,
+                VarbitID.IRONMAN,
+                type.getVarbitValue()
         );
     }
 }


### PR DESCRIPTION
Allows adding overloads for shops which container will only show when your account has specific account type.