### PR TITLE
PluginReloader: follow symlinks for external plugins directories

### DIFF
--- a/api/src/main/java/com/tonic/services/hotswapper/PluginReloader.java
+++ b/api/src/main/java/com/tonic/services/hotswapper/PluginReloader.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.FileVisitOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -213,7 +214,7 @@ public class PluginReloader {
         return Stream.of(external, sideloaded)
                 .flatMap(dir -> {
                     try {
-                        return Files.walk(dir);
+                        return Files.walk(dir, FileVisitOption.FOLLOW_LINKS);
                     } catch (IOException e) {
                         return Stream.empty();
                     }


### PR DESCRIPTION
WHY:
runelite follows the symlinks to load the plugins, but plugin reloader feature doesn't. allow plugins across multiple `-Duser.home=$HOME` to be symlinked back to a "base" plugin distribution.

HOW:
`FileVisitOption.FOLLOW_LINKS`

TESTED:
linux. plugin reloader now works. expect no side effects on other os?