### PR TITLE
feat(pathfinder): Add dialogue handling for jewelry teleports

### DIFF
--- a/api/src/main/java/com/tonic/services/pathfinder/teleports/TeleportLoader.java
+++ b/api/src/main/java/com/tonic/services/pathfinder/teleports/TeleportLoader.java
@@ -4,8 +4,11 @@ import com.tonic.Static;
 import com.tonic.api.game.GameAPI;
 import com.tonic.api.game.VarAPI;
 import com.tonic.api.game.WorldsAPI;
+import com.tonic.api.widgets.DialogueAPI;
 import com.tonic.api.widgets.EquipmentAPI;
 import com.tonic.api.widgets.InventoryAPI;
+import com.tonic.util.handler.HandlerBuilder;
+import com.tonic.util.handler.StepHandler;
 import com.tonic.data.wrappers.ItemEx;
 import com.tonic.data.wrappers.PlayerEx;
 import net.runelite.api.Client;
@@ -13,7 +16,6 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.VarPlayerID;
 import org.apache.commons.lang3.ArrayUtils;
 import java.util.*;
-import java.util.function.Predicate;
 
 public class TeleportLoader {
     public static List<Teleport> buildTeleports() {
@@ -59,180 +61,106 @@ public class TeleportLoader {
 
             if (getTeleportItem(MovementConstants.SLAYER_RING) != null && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(2432, 3423, 0), 2,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Teleport", "Stronghold", MovementConstants.SLAYER_RING));
-                        }}));
+                        jewelryTeleport("Teleport", "Stronghold", MovementConstants.SLAYER_RING)));
                 // todo if we have priest in peril
                 teleports.add(new Teleport(new WorldPoint(3422, 3537, 0), 2,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Teleport", "Slayer Tower", MovementConstants.SLAYER_RING));
-                        }}));
+                        jewelryTeleport("Teleport", "Slayer Tower", MovementConstants.SLAYER_RING)));
                 teleports.add(new Teleport(new WorldPoint(2802, 10000, 0), 2,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Teleport", "Fremennik", MovementConstants.SLAYER_RING));
-                        }}));
+                        jewelryTeleport("Teleport", "Fremennik", MovementConstants.SLAYER_RING)));
                 // todo if we have haunted mine
                 teleports.add(new Teleport(new WorldPoint(3185, 4601, 0), 2,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Teleport", "Tarn's Lair", MovementConstants.SLAYER_RING));
-                        }}));
+                        jewelryTeleport("Teleport", "Tarn's Lair", MovementConstants.SLAYER_RING)));
             }
             if (getTeleportItem(MovementConstants.AMULET_OF_GLORY) != null && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(3087, 3496, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Edgeville", MovementConstants.AMULET_OF_GLORY));
-                        }}));
+                        jewelryTeleport("Rub", "Edgeville", MovementConstants.AMULET_OF_GLORY)));
                 teleports.add(new Teleport(new WorldPoint(2918, 3176, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Karamja", MovementConstants.AMULET_OF_GLORY));
-                        }}));
+                        jewelryTeleport("Rub", "Karamja", MovementConstants.AMULET_OF_GLORY)));
                 teleports.add(new Teleport(new WorldPoint(3105, 3251, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Draynor Village", MovementConstants.AMULET_OF_GLORY));
-                        }}));
+                        jewelryTeleport("Rub", "Draynor Village", MovementConstants.AMULET_OF_GLORY)));
                 teleports.add(new Teleport(new WorldPoint(3293, 3163, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Al Kharid", MovementConstants.AMULET_OF_GLORY));
-                        }}));
+                        jewelryTeleport("Rub", "Al Kharid", MovementConstants.AMULET_OF_GLORY)));
             }
             if (getTeleportItem(MovementConstants.GAMES_NECKLACE) != null && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(2898, 3552, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Burthorpe", MovementConstants.GAMES_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Burthorpe", MovementConstants.GAMES_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(2521, 3571, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Barbarian Outpost", MovementConstants.GAMES_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Barbarian Outpost", MovementConstants.GAMES_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(2965, 4382, 2), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Corporeal Beast", MovementConstants.GAMES_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Corporeal Beast", MovementConstants.GAMES_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(3245, 9500, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Tears of Guthix", MovementConstants.GAMES_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Tears of Guthix", MovementConstants.GAMES_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(1625, 3937, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Wintertodt Camp", MovementConstants.GAMES_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Wintertodt Camp", MovementConstants.GAMES_NECKLACE)));
             }
             if (getTeleportItem(MovementConstants.RING_OF_WEALTH) != null && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(2535, 3862, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Miscellania", MovementConstants.RING_OF_WEALTH));
-                        }}));
+                        jewelryTeleport("Rub", "Miscellania", MovementConstants.RING_OF_WEALTH)));
                 teleports.add(new Teleport(new WorldPoint(3162, 3480, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Grand Exchange", MovementConstants.RING_OF_WEALTH));
-                        }}));
+                        jewelryTeleport("Rub", "Grand Exchange", MovementConstants.RING_OF_WEALTH)));
                 teleports.add(new Teleport(new WorldPoint(2995, 3375, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Falador", MovementConstants.RING_OF_WEALTH));
-                        }}));
+                        jewelryTeleport("Rub", "Falador", MovementConstants.RING_OF_WEALTH)));
                 // todo if we have the "between a rock" quest
                 teleports.add(new Teleport(new WorldPoint(2831, 10165, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Dondakan", MovementConstants.RING_OF_WEALTH));
-                        }}));
+                        jewelryTeleport("Rub", "Dondakan", MovementConstants.RING_OF_WEALTH)));
             }
             if (getTeleportItem(MovementConstants.RING_OF_DUELING) != null && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(3315, 3235, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Emir's Arena", MovementConstants.RING_OF_DUELING));
-                        }}));
+                        jewelryTeleport("Rub", "Emir's Arena", MovementConstants.RING_OF_DUELING)));
                 teleports.add(new Teleport(new WorldPoint(2441, 3091, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Castle Wars", MovementConstants.RING_OF_DUELING));
-                        }}));
+                        jewelryTeleport("Rub", "Castle Wars", MovementConstants.RING_OF_DUELING)));
                 teleports.add(new Teleport(new WorldPoint(3151, 3636, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Ferox Enclave", MovementConstants.RING_OF_DUELING));
-                        }}));
+                        jewelryTeleport("Rub", "Ferox Enclave", MovementConstants.RING_OF_DUELING)));
                 if (VarAPI.getVarp(VarPlayerID.COLOSSEUM_GLORY) >= 12000) {
                     teleports.add(new Teleport(new WorldPoint(1791, 3107, 0), 3,
-                            new ArrayList<>() {{
-                                addAll(jewelryTeleport("Rub", "Fortis Colosseum", MovementConstants.RING_OF_DUELING));
-                            }}));
+                            jewelryTeleport("Rub", "Fortis Colosseum", MovementConstants.RING_OF_DUELING)));
                 }
             }
             if (getTeleportItem(MovementConstants.COMBAT_BRACELET) != null && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(2883, 3549, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Warriors' Guild", MovementConstants.COMBAT_BRACELET));
-                        }}));
+                        jewelryTeleport("Rub", "Warriors' Guild", MovementConstants.COMBAT_BRACELET)));
                 teleports.add(new Teleport(new WorldPoint(3189, 3368, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Champions' Guild", MovementConstants.COMBAT_BRACELET));
-                        }}));
+                        jewelryTeleport("Rub", "Champions' Guild", MovementConstants.COMBAT_BRACELET)));
                 teleports.add(new Teleport(new WorldPoint(3053, 3487, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Monastery", MovementConstants.COMBAT_BRACELET));
-                        }}));
+                        jewelryTeleport("Rub", "Monastery", MovementConstants.COMBAT_BRACELET)));
                 teleports.add(new Teleport(new WorldPoint(2654, 3441, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Ranging Guild", MovementConstants.COMBAT_BRACELET));
-                        }}));
+                        jewelryTeleport("Rub", "Ranging Guild", MovementConstants.COMBAT_BRACELET)));
             }
             if (getTeleportItem(MovementConstants.SKILLS_NECKLACE) != null && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(2612, 3391, 0), 4,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Fishing Guild", MovementConstants.SKILLS_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Fishing Guild", MovementConstants.SKILLS_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(3049, 9764, 0), 4,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Mining Guild", MovementConstants.SKILLS_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Mining Guild", MovementConstants.SKILLS_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(2933, 3297, 0), 4,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Crafting Guild", MovementConstants.SKILLS_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Crafting Guild", MovementConstants.SKILLS_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(3145, 3439, 0), 2,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Cooking Guild", MovementConstants.SKILLS_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Cooking Guild", MovementConstants.SKILLS_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(1662, 3505, 0), 3,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Woodcutting Guild", MovementConstants.SKILLS_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Woodcutting Guild", MovementConstants.SKILLS_NECKLACE)));
                 teleports.add(new Teleport(new WorldPoint(1249, 3718, 0), 3,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Farming Guild", MovementConstants.SKILLS_NECKLACE));
-                        }}));
+                        jewelryTeleport("Rub", "Farming Guild", MovementConstants.SKILLS_NECKLACE)));
             }
-            if (InventoryAPI.getItem(i -> ArrayUtils.contains(MovementConstants.DIGSITE_PENDANT, i.getId())) != null && inMembers) {
+            if (InventoryAPI.getItem(i -> ArrayUtils.contains(MovementConstants.DIGSITE_PENDANT, i.getId())) != null
+                    && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(3341, 3444, 0), 3,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Digsite", MovementConstants.DIGSITE_PENDANT));
-                        }}));
+                        jewelryTeleport("Rub", "Digsite", MovementConstants.DIGSITE_PENDANT)));
                 // TODO implement requirements for Fossil Island and Lithkren
-                // couldn't find the vars for it
-                /*
-                teleports.add(new Teleport(new WorldPoint(3762, 3869, 1), 3,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Fossil Island", MovementConstants.DIGSITE_PENDANT));
-                        }}));
-                teleports.add(new Teleport(new WorldPoint(1,2,3), 3,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Lithkren", MovementConstants.DIGSITE_PENDANT));
-                        }}));*/
             }
             if (getTeleportItem(MovementConstants.NECKLACE_OF_PASSAGE) != null && inMembers) {
                 teleports.add(new Teleport(new WorldPoint(3114, 3181, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Wizards' Tower", MovementConstants.NECKLACE_OF_PASSAGE));
-                        }}));
+                        jewelryTeleport("Rub", "Wizards' Tower", MovementConstants.NECKLACE_OF_PASSAGE)));
                 teleports.add(new Teleport(new WorldPoint(2431, 3348, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "The Outpost", MovementConstants.NECKLACE_OF_PASSAGE));
-                        }}));
+                        jewelryTeleport("Rub", "The Outpost", MovementConstants.NECKLACE_OF_PASSAGE)));
                 teleports.add(new Teleport(new WorldPoint(3406, 3157, 0), 5,
-                        new ArrayList<>() {{
-                            addAll(jewelryTeleport("Rub", "Eagles' Eyrie", MovementConstants.NECKLACE_OF_PASSAGE));
-                        }}));
+                        jewelryTeleport("Rub", "Eagles' Eyrie", MovementConstants.NECKLACE_OF_PASSAGE)));
             }
             if (InventoryAPI.getItem(i -> ArrayUtils.contains(MovementConstants.BURNING_AMULET, i.getId())) != null) {
-                //TODO
+                teleports.add(new Teleport(new WorldPoint(3236, 3635, 0), 5,
+                        jewelryTeleport("Rub", "Chaos Temple", MovementConstants.BURNING_AMULET)));
+                teleports.add(new Teleport(new WorldPoint(3038, 3697, 0), 5,
+                        jewelryTeleport("Rub", "Bandit Camp", MovementConstants.BURNING_AMULET)));
+                teleports.add(new Teleport(new WorldPoint(3029, 3843, 0), 5,
+                        jewelryTeleport("Rub", "Lava Maze", MovementConstants.BURNING_AMULET)));
             }
 
             return teleports;
@@ -288,22 +216,30 @@ public class TeleportLoader {
         return InventoryAPI.getItem(i -> ArrayUtils.contains(ids, i.getId()));
     }
 
+    public static StepHandler jewelryTeleport(String itemAction, String target, int... ids) {
+        return HandlerBuilder.get()
+                .add(0, () -> {
 
-    public static List<Runnable> jewelryTeleport(String itemAction, String target, int... ids) {
-        return new ArrayList<>() {{
-            add(() -> {
-                ItemEx equipmentItem = EquipmentAPI.getItem(i -> ArrayUtils.contains(ids, i.getId()));
-                if (equipmentItem != null) {
-                    EquipmentAPI.interact(equipmentItem, target);
-                    return;
-                }
-                ItemEx item = InventoryAPI.getItem(i -> ArrayUtils.contains(ids, i.getId()));
-                if (item == null)
-                    return;
-                Static.invoke(() ->
-                    InventoryAPI.interactSubOp(item, itemAction, target));
-            });
-        }};
+                    ItemEx eqItem = EquipmentAPI.getItem(i -> ArrayUtils.contains(ids, i.getId()));
+                    if (eqItem != null) {
+                        EquipmentAPI.interact(eqItem, target);
+                        return 1;
+                    }
+                    ItemEx invItem = InventoryAPI.getItem(i -> ArrayUtils.contains(ids, i.getId()));
+                    if (invItem == null)
+                        return 0;
+                    Static.invoke(() -> InventoryAPI.interactSubOp(invItem, itemAction, target));
+                    return 1;
+                })
+                .addDelay(1, 1)
+                .add(2, () -> {
+                    if (DialogueAPI.optionPresent(target)) {
+                        DialogueAPI.selectOption(target);
+                    }
+                    return 3;
+                })
+                .addDelay(3, 3)
+                .build();
     }
 
     private static boolean membersCheck(int... ids)


### PR DESCRIPTION
Replace jewelryTeleport List<Runnable> with StepHandler that auto-detects and handles destination selection dialogues. Fixes Burning Amulet teleports while maintaining compatibility with direct-teleport jewelry items.
- jewelryTeleport() now returns StepHandler with dialogue detection
- Added DialogueAPI, HandlerBuilder