### PR TITLE
Add logging with SLF4J-style {} placeholders.

### DIFF
--- a/base-api/src/main/java/com/tonic/util/LoggerFormatting.java
+++ b/base-api/src/main/java/com/tonic/util/LoggerFormatting.java
@@ -1,0 +1,371 @@
+package com.tonic.util;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LoggerFormatting {
+    static final char DELIM_START = '{';
+    static final char DELIM_STOP = '}';
+    static final String DELIM_STR = "{}";
+    private static final char ESCAPE_CHAR = '\\';
+
+    final public static FormattingTuple arrayFormat(final String messagePattern, final Object[] argArray) {
+        Throwable throwableCandidate = getThrowableCandidate(argArray);
+        Object[] args = argArray;
+        if (throwableCandidate != null) {
+            args = LoggerFormatting.trimmedCopy(argArray);
+        }
+        return arrayFormat(messagePattern, args, throwableCandidate);
+    }
+
+
+    final public static FormattingTuple arrayFormat(final String messagePattern, final Object[] argArray, Throwable throwable) {
+
+        if (messagePattern == null) {
+            return new FormattingTuple(null, argArray, throwable);
+        }
+
+        if (argArray == null) {
+            return new FormattingTuple(messagePattern);
+        }
+
+        int i = 0;
+        int j;
+        // use string builder for better multicore performance
+        StringBuilder sbuf = new StringBuilder(messagePattern.length() + 50);
+
+        int L;
+        for (L = 0; L < argArray.length; L++) {
+
+            j = messagePattern.indexOf(DELIM_STR, i);
+
+            if (j == -1) {
+                // no more variables
+                if (i == 0) { // this is a simple string
+                    return new FormattingTuple(messagePattern, argArray, throwable);
+                } else { // add the tail string which contains no variables and return
+                    // the result.
+                    sbuf.append(messagePattern, i, messagePattern.length());
+                    return new FormattingTuple(sbuf.toString(), argArray, throwable);
+                }
+            } else {
+                if (isEscapedDelimeter(messagePattern, j)) {
+                    if (!isDoubleEscaped(messagePattern, j)) {
+                        L--; // DELIM_START was escaped, thus should not be incremented
+                        sbuf.append(messagePattern, i, j - 1);
+                        sbuf.append(DELIM_START);
+                        i = j + 1;
+                    } else {
+                        // The escape character preceding the delimiter start is
+                        // itself escaped: "abc x:\\{}"
+                        // we have to consume one backward slash
+                        sbuf.append(messagePattern, i, j - 1);
+                        deeplyAppendParameter(sbuf, argArray[L], new HashMap<>());
+                        i = j + 2;
+                    }
+                } else {
+                    // normal case
+                    sbuf.append(messagePattern, i, j);
+                    deeplyAppendParameter(sbuf, argArray[L], new HashMap<>());
+                    i = j + 2;
+                }
+            }
+        }
+        // append the characters following the last {} pair.
+        sbuf.append(messagePattern, i, messagePattern.length());
+        return new FormattingTuple(sbuf.toString(), argArray, throwable);
+    }
+
+
+
+    /**
+     * Helper method to determine if an {@link Object} array contains a
+     * {@link Throwable} as last element
+     *
+     * @param argArray The arguments off which we want to know if it contains a
+     *                 {@link Throwable} as last element
+     * @return if the last {@link Object} in argArray is a {@link Throwable} this
+     *         method will return it, otherwise it returns null
+     */
+    public static Throwable getThrowableCandidate(final Object[] argArray) {
+        if (argArray == null || argArray.length == 0) {
+            return null;
+        }
+
+        final Object lastEntry = argArray[argArray.length - 1];
+        if (lastEntry instanceof Throwable) {
+            return (Throwable) lastEntry;
+        }
+
+        return null;
+    }
+
+
+    final static boolean isEscapedDelimeter(String messagePattern, int delimeterStartIndex) {
+
+        if (delimeterStartIndex == 0) {
+            return false;
+        }
+        char potentialEscape = messagePattern.charAt(delimeterStartIndex - 1);
+        if (potentialEscape == ESCAPE_CHAR) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+    final static boolean isDoubleEscaped(String messagePattern, int delimeterStartIndex) {
+        if (delimeterStartIndex >= 2 && messagePattern.charAt(delimeterStartIndex - 2) == ESCAPE_CHAR) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+
+    // special treatment of array values was suggested by 'lizongbo'
+    private static void deeplyAppendParameter(StringBuilder sbuf, Object o, Map<Object[], Object> seenMap) {
+        if (o == null) {
+            sbuf.append("null");
+            return;
+        }
+        if (!o.getClass().isArray()) {
+            safeObjectAppend(sbuf, o);
+        } else {
+            // check for primitive array types because they
+            // unfortunately cannot be cast to Object[]
+            if (o instanceof boolean[]) {
+                booleanArrayAppend(sbuf, (boolean[]) o);
+            } else if (o instanceof byte[]) {
+                byteArrayAppend(sbuf, (byte[]) o);
+            } else if (o instanceof char[]) {
+                charArrayAppend(sbuf, (char[]) o);
+            } else if (o instanceof short[]) {
+                shortArrayAppend(sbuf, (short[]) o);
+            } else if (o instanceof int[]) {
+                intArrayAppend(sbuf, (int[]) o);
+            } else if (o instanceof long[]) {
+                longArrayAppend(sbuf, (long[]) o);
+            } else if (o instanceof float[]) {
+                floatArrayAppend(sbuf, (float[]) o);
+            } else if (o instanceof double[]) {
+                doubleArrayAppend(sbuf, (double[]) o);
+            } else {
+                objectArrayAppend(sbuf, (Object[]) o, seenMap);
+            }
+        }
+    }
+
+    private static void safeObjectAppend(StringBuilder sbuf, Object o) {
+        try {
+            String oAsString = o.toString();
+            sbuf.append(oAsString);
+        } catch (Throwable t) {
+            System.out.println("Failed toString() invocation on an object of type [" + o.getClass().getName() + "]");
+            sbuf.append("[FAILED toString()]");
+        }
+    }
+
+    private static void objectArrayAppend(StringBuilder sbuf, Object[] a, Map<Object[], Object> seenMap) {
+        sbuf.append('[');
+        if (!seenMap.containsKey(a)) {
+            seenMap.put(a, null);
+            final int len = a.length;
+            for (int i = 0; i < len; i++) {
+                deeplyAppendParameter(sbuf, a[i], seenMap);
+                if (i != len - 1)
+                    sbuf.append(", ");
+            }
+            // allow repeats in siblings
+            seenMap.remove(a);
+        } else {
+            sbuf.append("...");
+        }
+        sbuf.append(']');
+    }
+
+    private static void booleanArrayAppend(StringBuilder sbuf, boolean[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void byteArrayAppend(StringBuilder sbuf, byte[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void charArrayAppend(StringBuilder sbuf, char[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void shortArrayAppend(StringBuilder sbuf, short[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void intArrayAppend(StringBuilder sbuf, int[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void longArrayAppend(StringBuilder sbuf, long[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void floatArrayAppend(StringBuilder sbuf, float[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void doubleArrayAppend(StringBuilder sbuf, double[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+
+
+
+
+    public class NormalizedParameters {
+
+        final String message;
+        final Object[] arguments;
+        final Throwable throwable;
+
+        public NormalizedParameters(String message, Object[] arguments, Throwable throwable) {
+            this.message = message;
+            this.arguments = arguments;
+            this.throwable = throwable;
+        }
+
+        public NormalizedParameters(String message, Object[] arguments) {
+            this(message, arguments, null);
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public Object[] getArguments() {
+            return arguments;
+        }
+
+        public Throwable getThrowable() {
+            return throwable;
+        }
+
+    }
+
+
+    /**
+     * Holds the results of formatting done by {@link LoggerFormatting}.
+     *
+     * @author Joern Huxhorn
+     */
+    public static class FormattingTuple {
+        private final String message;
+        private final Throwable throwable;
+        private final Object[] argArray;
+
+        public FormattingTuple(String message) {
+            this(message, null, null);
+        }
+
+        public FormattingTuple(String message, Object[] argArray, Throwable throwable) {
+            this.message = message;
+            this.throwable = throwable;
+            this.argArray = argArray;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public Object[] getArgArray() {
+            return argArray;
+        }
+
+        public Throwable getThrowable() {
+            return throwable;
+        }
+
+    }
+
+    /**
+     * Helper method to get all but the last element of an array
+     *
+     * @param argArray
+     *          The arguments from which we want to remove the last element
+     *
+     * @return a copy of the array without the last element
+     */
+    public static Object[] trimmedCopy(final Object[] argArray) {
+        if (argArray == null || argArray.length == 0) {
+            throw new IllegalStateException("non-sensical empty or null argument array");
+        }
+
+        final int trimmedLen = argArray.length - 1;
+
+        Object[] trimmed = new Object[trimmedLen];
+
+        if (trimmedLen > 0) {
+            System.arraycopy(argArray, 0, trimmed, 0, trimmedLen);
+        }
+
+        return trimmed;
+    }
+
+}


### PR DESCRIPTION
**Add SLF4J-style `{}` placeholder support to `Logger`**

Introduced `LoggerFormatting`, which extends the existing `Logger` to support SLF4J-style `{}` placeholders for message formatting.

Previously, callers had to manually concatenate variables:

```java
Logger.info("My debug vars. Var1=" + variable1 + ". Var2=" + variable2 + ". Var3=" + variable3);
```

With this change, structured formatting is now available:

```java
Logger.info("My debug vars. Var1={}. Var2={}. Var3={}", variable1, variable2, variable3);
```

This improves readability, reduces string-building noise, and aligns the logging API with common industry conventions.