### PR TITLE
Added QOL queries to NpcQuery. Added some QOL helpers to Spellbook enum. Added a simpler prayer(s) toggle & flick.

### DIFF
--- a/api/src/main/java/com/tonic/api/widgets/PrayerAPI.java
+++ b/api/src/main/java/com/tonic/api/widgets/PrayerAPI.java
@@ -510,4 +510,20 @@ public enum PrayerAPI {
 
         private final PrayerAPI[] prayerMap;
     }
+
+    public static void toggle(PrayerAPI prayer) {
+        if (prayer != null) {
+            prayer.turnOn();
+        }
+    }
+
+    public static void toggle(PrayerAPI... prayers) {
+        for (PrayerAPI prayer : prayers) {
+            if (prayer != null) {
+                prayer.turnOn();
+            }
+        }
+    }
+
+
 }

--- a/api/src/main/java/com/tonic/data/magic/SpellBook.java
+++ b/api/src/main/java/com/tonic/data/magic/SpellBook.java
@@ -1,9 +1,12 @@
 package com.tonic.data.magic;
 
 import com.tonic.Static;
+import com.tonic.api.game.QuestAPI;
 import com.tonic.api.game.VarAPI;
 import com.tonic.data.magic.spellbooks.Ancient;
 import com.tonic.data.magic.spellbooks.Standard;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
 import net.runelite.api.gameval.VarbitID;
 
 import java.util.*;
@@ -32,6 +35,30 @@ public enum SpellBook
                         .findFirst()
                         .orElse(null)
         );
+    }
+
+    public static boolean isOnStandardSpellbook() {
+        return getCurrent() == STANDARD;
+    }
+
+    public static boolean isOnAncientSpellbook() {
+        return getCurrent() == ANCIENT;
+    }
+
+    public static boolean isOnLunarSpellbook() {
+        return getCurrent() == LUNAR;
+    }
+
+    public static boolean isOnArceeusSpellbook() {
+        return getCurrent() == NECROMANCY;
+    }
+
+    public static boolean isAncientSpellbookUnlocked() {
+        return QuestAPI.getState(Quest.DESERT_TREASURE_I) == QuestState.FINISHED;
+    }
+
+    public static boolean isLunarSpellbookUnlocked() {
+        return QuestAPI.getState(Quest.LUNAR_DIPLOMACY) == QuestState.FINISHED;
     }
 
     public static Set<Spell> getCurrentOffensiveSpells()

--- a/api/src/main/java/com/tonic/queries/NpcQuery.java
+++ b/api/src/main/java/com/tonic/queries/NpcQuery.java
@@ -1,11 +1,16 @@
 package com.tonic.queries;
 
+import com.tonic.api.game.MovementAPI;
+import com.tonic.data.wrappers.ActorEx;
 import com.tonic.data.wrappers.NpcEx;
 import com.tonic.queries.abstractions.AbstractActorQuery;
 import com.tonic.services.GameManager;
 import com.tonic.util.TextUtil;
+import com.tonic.util.WorldPointUtil;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
 
 /**
  * A query class to filter and retrieve NPCs based on various criteria.
@@ -106,5 +111,59 @@ public class NpcQuery extends AbstractActorQuery<NpcEx, NpcQuery>
     public NpcQuery withNameContains(String name)
     {
         return removeIf(o -> o.getName() == null || !TextUtil.sanitize(o.getName()).toLowerCase().contains(name.toLowerCase()));
+    }
+
+    public NpcQuery alive() {
+        return removeIf(ActorEx::isDead);
+    }
+
+    public NpcQuery walkable() {
+        return removeIf(npc -> {
+            WorldArea npcArea = npc.getWorldArea();
+
+            if (npcArea == null) {
+                return true;
+            }
+
+            int minX = npcArea.getX() - 1;
+            int minY = npcArea.getY() - 1;
+            int maxX = npcArea.getX() + npcArea.getWidth();
+            int maxY = npcArea.getY() + npcArea.getHeight();
+            int plane = npcArea.getPlane();
+
+            for (int x = minX; x <= maxX; x++) {
+                for (int y = minY; y <= maxY; y++) {
+                    if (x >= npcArea.getX() && x < npcArea.getX() + npcArea.getWidth() &&
+                    y >= npcArea.getY() && y < npcArea.getY() + npcArea.getHeight()) {
+                        continue;
+                    }
+
+                    boolean isCorner = (x == minX || x == maxX) && (y == minY || y == maxY);
+
+                    if (isCorner) {
+                        continue;
+                    }
+
+                    WorldPoint tile = new WorldPoint(x, y, plane);
+                    if (MovementAPI.canPathTo(tile)) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        });
+    }
+
+    public NpcQuery withinWorldArea(WorldArea area) {
+        return removeIf(npc -> {
+            WorldPoint npcWorldPoint = npc.getWorldPoint();
+
+            if (npcWorldPoint == null) {
+                return true;
+            }
+
+            return !area.contains(npcWorldPoint);
+        });
     }
 }


### PR DESCRIPTION
Added QOL queries to NpcQuery, such as ``alive()``, ``walkable()``, ``withinWorldArea(WorldArea worldArea)``.

Added some QOL helpers to Spellbook enum. Started adding this into a SpellbookAPI class until I noticed that the Spellbook enum existed.

Added a simpler way to toggle on one or multiple prayers.
``PrayerAPI.toggle(PrayerAPI.REDEMPTION)`` or ``PrayerAPI.toggle(PrayerAPI.REDEMPTION, PrayerAPI.PIETY);``