### PR TITLE
BankAPI update/fix for setX(...)

### DIFF
--- a/api/src/main/java/com/tonic/api/widgets/BankAPI.java
+++ b/api/src/main/java/com/tonic/api/widgets/BankAPI.java
@@ -15,9 +15,11 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.widgets.Widget;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 /**
@@ -57,25 +59,168 @@ public class BankAPI
     }
 
     /**
-     * Sets the withdraw amount to the specified amount.
-     * @param amount The amount to set the withdraw amount to.
+     * Sets the withdraw quantity mode.
+     * Supports preset quantities (1, 5, 10, all) for compatibility and custom X amounts.
+     * @param amount The quantity mode amount.
      */
     public static void setX(int amount)
     {
-        System.out.println(VarAPI.getVar(VarbitID.BANK_QUANTITY_TYPE));
+        if (BankQuantityResolver.isPresetAmount(amount))
+        {
+            setPresetQuantityMode(amount);
+            return;
+        }
+
         int withdrawMode = VarAPI.getVar(VarbitID.BANK_QUANTITY_TYPE);
         if(withdrawMode != 3)
         {
             WidgetAPI.interact(1, InterfaceID.Bankmain.QUANTITYX, -1, -1);
+            waitForCondition(() -> VarAPI.getVar(VarbitID.BANK_QUANTITY_TYPE) == 3, 350);
         }
 
         int xQuantity = getX();
-        if(xQuantity != amount && amount != 1 && amount != 5 && amount != 10 && amount != -1)
+        if(xQuantity != amount)
         {
             WidgetAPI.interact(2, InterfaceID.Bankmain.QUANTITYX, -1, -1);
+            waitBriefly(25);
             DialogueAPI.resumeNumericDialogue(amount);
             XSnapshot.amount = amount;
             XSnapshot.tick = GameManager.getTickCount();
+            waitForCondition(() -> VarAPI.getVar(VarbitID.BANK_REQUESTEDQUANTITY) == amount, 350);
+        }
+    }
+
+    private static void setPresetQuantityMode(int amount)
+    {
+        switch (amount)
+        {
+            case 1:
+                clickQuantityButton(InterfaceID.Bankmain.QUANTITY1, InterfaceID.Bankmain.QUANTITY1_TEXT);
+                break;
+            case 5:
+                clickQuantityButton(InterfaceID.Bankmain.QUANTITY5, InterfaceID.Bankmain.QUANTITY5_TEXT);
+                break;
+            case 10:
+                clickQuantityButton(InterfaceID.Bankmain.QUANTITY10, InterfaceID.Bankmain.QUANTITY10_TEXT);
+                break;
+            case -1:
+                clickQuantityButton(InterfaceID.Bankmain.QUANTITYALL, InterfaceID.Bankmain.QUANTITYALL_TEXT);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static void clickQuantityButton(int primaryWidgetId, int fallbackWidgetId)
+    {
+        if (WidgetAPI.isVisible(primaryWidgetId))
+        {
+            WidgetAPI.interact(1, primaryWidgetId, -1, -1);
+            return;
+        }
+        WidgetAPI.interact(1, fallbackWidgetId, -1, -1);
+    }
+
+    private static int resolveItemSlot(int containerWidgetId, int preferredSlot, int itemId)
+    {
+        Widget container = WidgetAPI.get(containerWidgetId);
+        if (container == null)
+        {
+            return -1;
+        }
+
+        if (preferredSlot >= 0)
+        {
+            Widget preferred = Static.invoke(() -> container.getChild(preferredSlot));
+            if (preferred != null && preferred.getItemId() == itemId && preferred.getItemQuantity() > 0)
+            {
+                return preferredSlot;
+            }
+        }
+
+        Widget[] children = Static.invoke(container::getChildren);
+        if (children == null)
+        {
+            return -1;
+        }
+
+        for (int i = 0; i < children.length; i++)
+        {
+            Widget child = children[i];
+            if (child == null)
+            {
+                continue;
+            }
+            if (child.getItemId() == itemId && child.getItemQuantity() > 0)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static boolean interactItemByAction(int containerWidgetId, int slot, int itemId, String action)
+    {
+        Widget container = WidgetAPI.get(containerWidgetId);
+        if (container == null)
+        {
+            return false;
+        }
+
+        Widget widget = Static.invoke(() -> container.getChild(slot));
+        if (widget == null || widget.getItemId() != itemId || widget.getItemQuantity() <= 0)
+        {
+            return false;
+        }
+
+        WidgetAPI.interact(widget, action);
+        return true;
+    }
+
+    private static void waitForCondition(BooleanSupplier condition, int timeoutMs)
+    {
+        Client client = Static.getClient();
+        if (client == null || client.isClientThread() || timeoutMs <= 0)
+        {
+            return;
+        }
+
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline)
+        {
+            if (condition.getAsBoolean())
+            {
+                return;
+            }
+
+            try
+            {
+                Thread.sleep(20L);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private static void waitBriefly(int milliseconds)
+    {
+        Client client = Static.getClient();
+        if (client == null || client.isClientThread() || milliseconds <= 0)
+        {
+            return;
+        }
+
+        try
+        {
+            Thread.sleep(milliseconds);
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -359,22 +504,24 @@ public class BankAPI
      * @param slot The slot of the item in the bank.
      */
     public static void withdrawAction(int id, int amount, int slot) {
-        setX(amount);
-        if(amount == 1) {
-            WidgetAPI.interact(1, InterfaceID.Bankmain.ITEMS, slot, id);
+        if(!BankQuantityResolver.isPresetAmount(amount))
+        {
+            setX(amount);
         }
-        else if(amount == 5) {
-            WidgetAPI.interact(3, InterfaceID.Bankmain.ITEMS, slot, id);
+
+        int resolvedSlot = resolveItemSlot(InterfaceID.Bankmain.ITEMS, slot, id);
+        if (resolvedSlot == -1)
+        {
+            return;
         }
-        else if(amount == 10) {
-            WidgetAPI.interact(4, InterfaceID.Bankmain.ITEMS, slot, id);
+
+        String action = BankQuantityResolver.withdrawMenuAction(amount);
+        if (interactItemByAction(InterfaceID.Bankmain.ITEMS, resolvedSlot, id, action))
+        {
+            return;
         }
-        else if(amount == -1) {
-            WidgetAPI.interact(7, InterfaceID.Bankmain.ITEMS, slot, id);
-        }
-        else {
-            WidgetAPI.interact(5, InterfaceID.Bankmain.ITEMS, slot, id);
-        }
+
+        WidgetAPI.interact(BankQuantityResolver.withdrawFallbackAction(amount), InterfaceID.Bankmain.ITEMS, resolvedSlot, id);
     }
 
     /**
@@ -384,22 +531,24 @@ public class BankAPI
      * @param slot The slot of the item in the inventory.
      */
     public static void depositAction(int id, int amount, int slot) {
-        setX(amount);
-        if(amount == 1) {
-            WidgetAPI.interact(2, InterfaceID.Bankside.ITEMS, slot, id);
+        if(!BankQuantityResolver.isPresetAmount(amount))
+        {
+            setX(amount);
         }
-        else if(amount == 5) {
-            WidgetAPI.interact(4, InterfaceID.Bankside.ITEMS, slot, id);
+
+        int resolvedSlot = resolveItemSlot(InterfaceID.Bankside.ITEMS, slot, id);
+        if (resolvedSlot == -1)
+        {
+            return;
         }
-        else if(amount == 10) {
-            WidgetAPI.interact(5, InterfaceID.Bankside.ITEMS, slot, id);
+
+        String action = BankQuantityResolver.depositMenuAction(amount);
+        if (interactItemByAction(InterfaceID.Bankside.ITEMS, resolvedSlot, id, action))
+        {
+            return;
         }
-        else if(amount == -1) {
-            WidgetAPI.interact(8, InterfaceID.Bankside.ITEMS, slot, id);
-        }
-        else {
-            WidgetAPI.interact(6, InterfaceID.Bankside.ITEMS, slot, id);
-        }
+
+        WidgetAPI.interact(BankQuantityResolver.depositFallbackAction(amount), InterfaceID.Bankside.ITEMS, resolvedSlot, id);
     }
 
     /**

--- a/api/src/main/java/com/tonic/api/widgets/BankQuantityResolver.java
+++ b/api/src/main/java/com/tonic/api/widgets/BankQuantityResolver.java
@@ -1,0 +1,81 @@
+package com.tonic.api.widgets;
+
+final class BankQuantityResolver
+{
+    private BankQuantityResolver()
+    {
+    }
+
+    static boolean isPresetAmount(int amount)
+    {
+        return amount == 1 || amount == 5 || amount == 10 || amount == -1;
+    }
+
+    static String withdrawMenuAction(int amount)
+    {
+        switch (amount)
+        {
+            case 1:
+                return "Withdraw-1";
+            case 5:
+                return "Withdraw-5";
+            case 10:
+                return "Withdraw-10";
+            case -1:
+                return "Withdraw-All";
+            default:
+                return "Withdraw-X";
+        }
+    }
+
+    static int withdrawFallbackAction(int amount)
+    {
+        switch (amount)
+        {
+            case 1:
+                return 1;
+            case 5:
+                return 3;
+            case 10:
+                return 4;
+            case -1:
+                return 7;
+            default:
+                return 5;
+        }
+    }
+
+    static String depositMenuAction(int amount)
+    {
+        switch (amount)
+        {
+            case 1:
+                return "Deposit-1";
+            case 5:
+                return "Deposit-5";
+            case 10:
+                return "Deposit-10";
+            case -1:
+                return "Deposit-All";
+            default:
+                return "Deposit-X";
+        }
+    }
+
+    static int depositFallbackAction(int amount)
+    {
+        switch (amount)
+        {
+            case 1:
+                return 2;
+            case 5:
+                return 4;
+            case 10:
+                return 5;
+            case -1:
+                return 8;
+            default:
+                return 6;
+        }
+    }
+}

--- a/api/src/test/java/com/tonic/api/widgets/BankQuantityResolverTest.java
+++ b/api/src/test/java/com/tonic/api/widgets/BankQuantityResolverTest.java
@@ -1,0 +1,67 @@
+package com.tonic.api.widgets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BankQuantityResolverTest
+{
+    @Test
+    void presetDetectionIsStable()
+    {
+        assertTrue(BankQuantityResolver.isPresetAmount(1));
+        assertTrue(BankQuantityResolver.isPresetAmount(5));
+        assertTrue(BankQuantityResolver.isPresetAmount(10));
+        assertTrue(BankQuantityResolver.isPresetAmount(-1));
+        assertFalse(BankQuantityResolver.isPresetAmount(2));
+        assertFalse(BankQuantityResolver.isPresetAmount(50));
+    }
+
+    @Test
+    void withdrawMappingMatchesBankMenuContract()
+    {
+        assertEquals("Withdraw-1", BankQuantityResolver.withdrawMenuAction(1));
+        assertEquals("Withdraw-5", BankQuantityResolver.withdrawMenuAction(5));
+        assertEquals("Withdraw-10", BankQuantityResolver.withdrawMenuAction(10));
+        assertEquals("Withdraw-All", BankQuantityResolver.withdrawMenuAction(-1));
+        assertEquals("Withdraw-X", BankQuantityResolver.withdrawMenuAction(42));
+
+        assertEquals(1, BankQuantityResolver.withdrawFallbackAction(1));
+        assertEquals(3, BankQuantityResolver.withdrawFallbackAction(5));
+        assertEquals(4, BankQuantityResolver.withdrawFallbackAction(10));
+        assertEquals(7, BankQuantityResolver.withdrawFallbackAction(-1));
+        assertEquals(5, BankQuantityResolver.withdrawFallbackAction(42));
+    }
+
+    @Test
+    void mixedWithdrawAmountsRemainDeterministic()
+    {
+        int[] amounts = {3, -1, 1, -1, 7};
+        String[] expectedMenuActions = {"Withdraw-X", "Withdraw-All", "Withdraw-1", "Withdraw-All", "Withdraw-X"};
+        int[] expectedFallbacks = {5, 7, 1, 7, 5};
+
+        for (int i = 0; i < amounts.length; i++)
+        {
+            assertEquals(expectedMenuActions[i], BankQuantityResolver.withdrawMenuAction(amounts[i]));
+            assertEquals(expectedFallbacks[i], BankQuantityResolver.withdrawFallbackAction(amounts[i]));
+        }
+    }
+
+    @Test
+    void depositMappingMatchesBankMenuContract()
+    {
+        assertEquals("Deposit-1", BankQuantityResolver.depositMenuAction(1));
+        assertEquals("Deposit-5", BankQuantityResolver.depositMenuAction(5));
+        assertEquals("Deposit-10", BankQuantityResolver.depositMenuAction(10));
+        assertEquals("Deposit-All", BankQuantityResolver.depositMenuAction(-1));
+        assertEquals("Deposit-X", BankQuantityResolver.depositMenuAction(42));
+
+        assertEquals(2, BankQuantityResolver.depositFallbackAction(1));
+        assertEquals(4, BankQuantityResolver.depositFallbackAction(5));
+        assertEquals(5, BankQuantityResolver.depositFallbackAction(10));
+        assertEquals(8, BankQuantityResolver.depositFallbackAction(-1));
+        assertEquals(6, BankQuantityResolver.depositFallbackAction(42));
+    }
+}


### PR DESCRIPTION
1. Stopped setX(...) from forcing X mode for preset amounts (1, 5, 10, -1), so those calls no longer mutate bank quantity state unexpectedly. `BankAPI.setX(1|5|10|-1)` now sets the corresponding bank quantity buttons instead of no-op
- Backwards compatibility kept intact

2. Added explicit action-by-name item interactions (Withdraw-1, Withdraw-All, Deposit-1, etc.) before numeric fallback
- Withdraw/deposit amount selection is no longer tied to mutable left-click quantity mode

3. Custom X timing hardening
- Added guarded waits around switching to X mode and applying `BANK_REQUESTEDQUANTITY` to reduce packet/desync timing issues

4. Stale-slot safety for mixed withdraw/deposit flows
- Added slot re-resolution before interaction, so we don’t act on stale slot indices after prior bank mutations
- If item can’t be resolved in the container, action aborts safely