### PR TITLE
Add Quetzal transport system, Xeric's Talisman teleports, and teleport improvements

### DIFF
--- a/api/src/main/java/com/tonic/services/pathfinder/teleports/TeleportItem.java
+++ b/api/src/main/java/com/tonic/services/pathfinder/teleports/TeleportItem.java
@@ -2,6 +2,7 @@ package com.tonic.services.pathfinder.teleports;
 
 import com.tonic.api.entities.PlayerAPI;
 import com.tonic.api.game.VarAPI;
+import com.tonic.api.widgets.EquipmentAPI;
 import com.tonic.api.widgets.InventoryAPI;
 import net.runelite.api.ItemID;
 import net.runelite.api.Quest;
@@ -78,20 +79,27 @@ public enum TeleportItem
     JATIZSO_LYRE(new WorldPoint(2409, 3809, 0), "Jatizso", Quest.THE_FREMENNIK_TRIALS, MovementConstants.ENCHANTED_LYRE),
 
     // Diary
-    ARDOUGNE_CLOAK(new WorldPoint(2606, 3222, 0), "Monastery Teleport", null, MovementConstants.ARDOUGNE_CLOAK)
+    ARDOUGNE_CLOAK(new WorldPoint(2606, 3222, 0), "Monastery Teleport", "Kandarin Monastery", null, MovementConstants.ARDOUGNE_CLOAK)
     ;
 
     private final WorldPoint destination;
     private final Quest requirement;
     private final int[] itemIds;
     private final String action;
+    private final String equippedAction;
 
     TeleportItem(WorldPoint destination, String action, Quest requirement, int... itemIds)
+    {
+        this(destination, action, null, requirement, itemIds);
+    }
+
+    TeleportItem(WorldPoint destination, String action, String equippedAction, Quest requirement, int... itemIds)
     {
         this.destination = destination;
         this.requirement = requirement;
         this.itemIds = itemIds;
         this.action = action;
+        this.equippedAction = equippedAction;
     }
 
     public WorldPoint getDestination()
@@ -109,9 +117,19 @@ public enum TeleportItem
         return action;
     }
 
+    public String getEquippedAction()
+    {
+        return equippedAction != null ? equippedAction : action;
+    }
+
     public boolean canUse()
     {
-        return hasRequirements() && InventoryAPI.getItem(i -> ArrayUtils.contains(itemIds, i.getId())) != null;
+        if (!hasRequirements()) {
+            return false;
+        }
+
+        return InventoryAPI.getItem(i -> ArrayUtils.contains(itemIds, i.getId())) != null ||
+                EquipmentAPI.getItem(i -> ArrayUtils.contains(itemIds, i.getId())) != null;
     }
 
     public boolean hasRequirements()

--- a/api/src/main/java/com/tonic/services/pathfinder/teleports/TeleportLoader.java
+++ b/api/src/main/java/com/tonic/services/pathfinder/teleports/TeleportLoader.java
@@ -246,6 +246,20 @@ public class TeleportLoader {
                 //TODO
             }
 
+            if (getTeleportItem(MovementConstants.XERICS_TALISMAN) != null && inMembers) {
+                teleports.add(new Teleport(new WorldPoint(1579, 3530, 0), 5,
+                        jewelryTeleport("Rub", "Xeric's Lookout", MovementConstants.XERICS_TALISMAN)));
+                teleports.add(new Teleport(new WorldPoint(1752, 3566, 0), 5,
+                        jewelryTeleport("Rub", "Xeric's Glade", MovementConstants.XERICS_TALISMAN)));
+                teleports.add(new Teleport(new WorldPoint(1504, 3817, 0), 5,
+                        jewelryTeleport("Rub", "Xeric's Inferno", MovementConstants.XERICS_TALISMAN)));
+                teleports.add(new Teleport(new WorldPoint(1642, 3674, 0), 5,
+                        jewelryTeleport("Rub", "Xeric's Heart", MovementConstants.XERICS_TALISMAN)));
+                // TODO: Add check for ancient tablet unlock
+                //teleports.add(new Teleport(new WorldPoint(x, x, x), 5,
+                //         jewelryTeleport("Rub", "Xeric's Honour", MovementConstants.XERICS_TALISMAN)));
+            }
+
             return teleports;
         });
     }
@@ -288,11 +302,14 @@ public class TeleportLoader {
 
     public static Teleport itemTeleport(TeleportItem teleportItem) {
         return new Teleport(teleportItem.getDestination(), 5, new ArrayList<>() {{
-            add(() ->
-            {
-                ItemEx item = InventoryAPI.getItem(i -> ArrayUtils.contains(teleportItem.getItemId(), i.getId()));
+            add(() -> {
+                ItemEx item = getTeleportItem(teleportItem.getItemId());
                 if (item != null) {
-                    InventoryAPI.interact(item, teleportItem.getAction());
+                    if (EquipmentAPI.isEquipped(item.getId())) {
+                        EquipmentAPI.interact(item, teleportItem.getEquippedAction());
+                    } else {
+                        InventoryAPI.interact(item, teleportItem.getAction());
+                    }
                 }
             });
         }});

--- a/api/src/main/java/com/tonic/services/pathfinder/transports/TransportLoader.java
+++ b/api/src/main/java/com/tonic/services/pathfinder/transports/TransportLoader.java
@@ -432,6 +432,7 @@ public class TransportLoader
                 kourendMinecartNetwork(LAST_TRANSPORT_LIST);
                 gnomeGliders(LAST_TRANSPORT_LIST);
                 fairyRings(LAST_TRANSPORT_LIST);
+                quetzalTransport(LAST_TRANSPORT_LIST);
                 dwarvenCarts(LAST_TRANSPORT_LIST);
                 canoes(LAST_TRANSPORT_LIST);
             }
@@ -518,13 +519,22 @@ public class TransportLoader
                 {
                     HandlerBuilder builder = HandlerBuilder.get()
                             .add(0, () -> {
+                                if (!EquipmentAPI.isEquipped(ItemID.DRAMEN_STAFF) && !EquipmentAPI.isEquipped(ItemID.LUNAR_STAFF)) {
+                                    ItemEx staff = InventoryAPI.getItem(i -> i.getId() == ItemID.DRAMEN_STAFF || i.getId() == ItemID.LUNAR_STAFF);
+                                    if (staff != null) {
+                                        EquipmentAPI.equip(staff.getId());
+                                    }
+                                }
+                                return 1;
+                            })
+                            .add(1, () -> {
                                 TileObjectEx current = new TileObjectQuery()
                                         .withName("Fairy ring")
                                         .first();
                                 TileObjectAPI.interact(current, "Zanaris");
-                                return 1;
+                                return 2;
                             })
-                            .addDelay(1, 7);
+                            .addDelay(2, 7);
 
                     Requirements merged = new Requirements();
                     merged.addRequirements(ring.getRequirements().getAll());
@@ -537,14 +547,23 @@ public class TransportLoader
 
                 HandlerBuilder builder = HandlerBuilder.get()
                         .add(0, () -> {
+                            if (!EquipmentAPI.isEquipped(ItemID.DRAMEN_STAFF) && !EquipmentAPI.isEquipped(ItemID.LUNAR_STAFF)) {
+                                ItemEx staff = InventoryAPI.getItem(i -> i.getId() == ItemID.DRAMEN_STAFF || i.getId() == ItemID.LUNAR_STAFF);
+                                if (staff != null) {
+                                    EquipmentAPI.equip(staff.getId());
+                                }
+                            }
+                            return 1;
+                        })
+                        .add(1, () -> {
                             TileObjectEx current = new TileObjectQuery()
                                     .withName("Fairy ring")
                                     .nearest();
                             TileObjectAPI.interact(current, "Configure");
-                            return 1;
+                            return 2;
                         })
                         .addDelayUntil(2, () -> WidgetAPI.get(InterfaceID.Fairyrings.CONFIRM) != null)
-                        .addDelayUntil(3, () -> !destination.travel())
+                        .addDelayUntil(3, destination::travel)
                         .addDelay(4, 7)
                         .add(5, () -> MovementAPI.walkToWorldPoint(destination.getLocation()))
                         .addDelay(6, 1);
@@ -589,6 +608,39 @@ public class TransportLoader
 
                 Transport transport = new Transport(WorldPointUtil.compress(glider.getLocation()), WorldPointUtil.compress(destination.getLocation()), 6, 1, 4, builder.build(), destination.getRequirements(), -1);
                 computeIfAbsent(transports, WorldPointUtil.compress(glider.getLocation()), transport);
+            }
+        }
+    }
+
+    private static void quetzalTransport(final TIntObjectHashMap<ArrayList<Transport>> transports)
+    {
+        for (QuetzalTransport start : QuetzalTransport.values())
+        {
+            for (QuetzalTransport destination : QuetzalTransport.values())
+            {
+                if (start == destination)
+                {
+                    continue;
+                }
+
+                HandlerBuilder builder = HandlerBuilder.get()
+                        .add(0, () -> {
+                            NpcEx npc = new NpcQuery().withName("Renu").first();
+                            if (npc != null) {
+                                NpcAPI.interact(npc, "Travel");
+                                return 1;
+                            }
+                            return -1;
+                        })
+                        .addDelayUntil(1, () -> WidgetAPI.get(InterfaceID.QuetzalMenu.ICONS) != null && WidgetAPI.isVisible(InterfaceID.QuetzalMenu.UNIVERSE))
+                        .add(2, () -> {
+                            WidgetAPI.interact(1, InterfaceID.QuetzalMenu.ICONS, destination.getIndex(), -1);
+                            return 3;
+                        })
+                        .addDelay(3, 5);
+
+                Transport transport = new Transport(WorldPointUtil.compress(start.getLocation()), WorldPointUtil.compress(destination.getLocation()), 0, 1, 5, builder.build(), start.getRequirements(), -1);
+                computeIfAbsent(transports, WorldPointUtil.compress(start.getLocation()), transport);
             }
         }
     }

--- a/api/src/main/java/com/tonic/services/pathfinder/transports/data/FairyRing.java
+++ b/api/src/main/java/com/tonic/services/pathfinder/transports/data/FairyRing.java
@@ -79,7 +79,7 @@ public enum FairyRing
         this.requirements = new Requirements();
         this.requirements.addRequirements(requirements);
         this.requirements.addRequirement(new QuestRequirement(Quest.FAIRYTALE_II__CURE_A_QUEEN, QuestState.IN_PROGRESS, QuestState.FINISHED));
-        this.requirements.addRequirement(new ItemRequirement(true, 1, ItemID.DRAMEN_STAFF));
+        this.requirements.addRequirement(new ItemRequirement(null, 1, ItemID.DRAMEN_STAFF, ItemID.LUNAR_STAFF));
     }
 
     private static final int[][] TURN_INDICES = {{19, 20}, {21, 22}, {23, 24}};

--- a/api/src/main/java/com/tonic/services/pathfinder/transports/data/QuetzalTransport.java
+++ b/api/src/main/java/com/tonic/services/pathfinder/transports/data/QuetzalTransport.java
@@ -1,0 +1,55 @@
+package com.tonic.services.pathfinder.transports.data;
+
+import com.tonic.services.pathfinder.requirements.*;
+import lombok.Getter;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.VarbitID;
+
+/**
+ * Quetzal Transport System landing sites in Varlamore.
+ * 8 destinations are unlocked by default.
+ * 6 destinations must be built by the player.
+ */
+@Getter
+public enum QuetzalTransport
+{
+    // Interface index order (0-13)
+    CIVITAS_ILLA_FORTIS("Civitas illa Fortis", new WorldPoint(1697, 3140, 0), VarbitID.QUETZAL_FORTIS, 0),
+    THE_TEOMAT("The Teomat", new WorldPoint(1437, 3171, 0), VarbitID.QUETZAL_TEOMAT, 1),
+    SUNSET_COAST("Sunset Coast", new WorldPoint(1548, 2995, 0), VarbitID.QUETZAL_SUNSETCOAST, 2),
+    HUNTER_GUILD("Hunter Guild", new WorldPoint(1585, 3053, 0), VarbitID.QUETZAL_HUNTERGUILD, 3),
+    CAM_TORUM_ENTRANCE("Cam Torum entrance", new WorldPoint(1495, 3753, 0), VarbitID.QUETZAL_CAMTORUM, 4),
+    COLOSSAL_WYRM_REMAINS("Colossal Wyrm Remains", new WorldPoint(1350, 3849, 0), VarbitID.QUETZAL_COLOSSALWYRM, 5),
+    OUTER_FORTIS("Outer Fortis", new WorldPoint(1800, 3425, 0), VarbitID.QUETZAL_OUTERFORTIS, 6),
+    FORTIS_COLOSSEUM("Fortis Colosseum", new WorldPoint(1791, 3107, 0), VarbitID.QUETZAL_COLOSSEUM, 7),
+    ALDARIN("Aldarin", new WorldPoint(1389, 2901, 0), VarbitID.QUETZAL_ALDARIN, 8),
+    QUETZACALLI_GORGE("Quetzacalli Gorge", new WorldPoint(1510, 3222, 0), VarbitID.QUETZAL_QUETZACALLIGORGE, 9),
+    SALVAGER_OVERLOOK("Salvager Overlook", new WorldPoint(1150, 3480, 0), VarbitID.QUETZAL_SALVAGEROVERLOOK, 10),
+    TAL_TEKLAN("Tal Teklan", new WorldPoint(1226, 3091, 0), VarbitID.QUETZAL_TALTEKLAN, 11),
+    AUBURNVALE("Auburnvale", new WorldPoint(1411, 3361, 0), VarbitID.QUETZAL_AUBURNVALLEY, 12),
+    KASTORI("Kastori", new WorldPoint(1585, 3053, 0), VarbitID.QUETZAL_KASTORI, 13);
+
+    private final String name;
+    private final WorldPoint location;
+    private final Requirements requirements;
+    private final int varbitId;
+    private final int interfaceIndex;
+
+    QuetzalTransport(String name, WorldPoint location, int varbitId, int interfaceIndex)
+    {
+        this.name = name;
+        this.location = location;
+        this.varbitId = varbitId;
+        this.interfaceIndex = interfaceIndex;
+        this.requirements = new Requirements();
+        this.requirements.addRequirements(new QuestRequirement(Quest.TWILIGHTS_PROMISE, QuestState.FINISHED));
+        this.requirements.addRequirements(new VarRequirement(Comparison.GREATER_THAN, VarType.VARBIT, varbitId, 0));
+    }
+
+    public int getIndex()
+    {
+        return interfaceIndex;
+    }
+}


### PR DESCRIPTION
Adds support for several additional transport methods and improves how teleport items and fairy rings are handled by the walker.

### New Features

**Quetzal Transport System**
- Added support for all 14 Quetzal landing sites in Varlamore
- Includes quest and varbit unlock checks before attempting travel

**Xeric's Talisman Teleports**
- Added support for the following destinations:
  - Xeric's Lookout
  - Xeric's Glade
  - Xeric's Inferno
  - Xeric's Heart

### Teleport Improvements

- Teleport items can now be used when **equipped as well as in inventory**
- Added an `equippedAction` field to support items that expose different actions when worn  
  (e.g. Ardougne cloak shows `Kandarin Monastery` when equipped but `Monastery Teleport` in inventory)

### Fairy Ring Improvements

- Fairy rings now work when the **Dramen or Lunar staff is in inventory**
- The handler will automatically equip the staff if needed

### Fix

- Fixed fairy ring handler logic that was checking `!destination.travel()`, which caused the handler to continue before the ring code was fully set and resulted in the Walker getting stuck.

### Files Added / Modified

Added:
- `QuetzalLanding.java`

Modified:
- `FairyRing.java`
- `TransportLoader.java`
- `TeleportItem.java`
- `TeleportLoader.java`

### Tested

- Quetzal transports between multiple landing sites
- Xeric's talisman teleports
- Ardougne cloak teleport when equipped
- Fairy rings with staff in inventory